### PR TITLE
Update urls.py for Django 4 compatibility

### DIFF
--- a/munin/urls.py
+++ b/munin/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from munin.views import total_users, active_users, total_sessions, \
     active_sessions, db_performance
 
 urlpatterns = [
-    url(r'^total_users/$', total_users),
-    url(r'^active_users/$', active_users),
-    url(r'^total_sessions/$', total_sessions),
-    url(r'^active_sessions/$', active_sessions),
-    url(r'^db_performance/$', db_performance),
+    re_path(r'^total_users/$', total_users),
+    re_path(r'^active_users/$', active_users),
+    re_path(r'^total_sessions/$', total_sessions),
+    re_path(r'^active_sessions/$', active_sessions),
+    re_path(r'^db_performance/$', db_performance),
 ]


### PR DESCRIPTION
This PR makes a change needed for compatibility with Django 4.

The file `urls.py` make use of the function `url`, which is deprecated since Django 3.0 and removed in Django 4.0. I replace it with its newer equivalent `re_path`, which was added in Django 2.0.

I would also be happy if you could clarify the maintenance status of this package (including pushing updates to PyPI). It is doing the job for us and we are happy to keep using it if we can include small updates like this one over the years!

I guess there are few remaining users of this package in the wild, and if [we](https://github.com/zestedesavoir/zds-site/) are the last project to use it and you prefer not to work on it anymore, it would be nice to know for us to decide on alternative solutions (e.g taking over the maintenance, integrating the features directly in our codebase, migrating to another monitoring solution, etc.).

Have a nice day. :-)